### PR TITLE
NewCapacityExpansionStop added in world region logic

### DIFF
--- a/Conversion Script/functions/process_parameters.py
+++ b/Conversion Script/functions/process_parameters.py
@@ -84,7 +84,7 @@ def process_regular_parameters(csv_file_path, unique_values_concatenated, output
        "Par_EmissionsPenalty",
        "Par_SpecifiedDemandDevelopment",
        "Par_RegionalModelPeriodEmission",
-       "Par_ModelPeriodExogenousEmissio"]:
+       "Par_ModelPeriodExogenousEmissio",]:
         df = set_regional_values_from_base(df, unique_values_concatenated, data_base_region)
     
     # Set values, if no regional data available
@@ -107,7 +107,8 @@ def process_regular_parameters(csv_file_path, unique_values_concatenated, output
         "Par_ModelPeriodExogenousEmissio",
         "Par_TotalAnnualMaxCapacity",
         "Par_SpecifiedDemandDevelopment",
-        "Par_AnnualMaxNewCapacity"
+        "Par_AnnualMaxNewCapacity",
+        "Par_NewCapacityExpansionStop"
         ]:
         df = set_values_from_world(df, unique_values_concatenated)
 


### PR DESCRIPTION
# 📌 Pull Request Summary

The parameter NewCapacityExpansionStop was missing in the list for parameters, that are included in the world region logic in the conversion script. This meant that values that are intended for all regions ("World") were ignored and the parameter did not take effect.

## 🔗 Related Issue(s)

## 🛠️ Changes Introduced

- Added the parameter "Par_NewCapacityExpansionStop" in the world region logic in the conversion script

## 📋 Checklist

- [x] Code follows project conventions
- [ ] Tests have been added/updated (if needed)
- [ ] Documentation has been updated (if applicable)
- [ ] Relevant issues linked
- [x] Reviewers assigned
