### PR TITLE
Par_GroupTotalAnnualMaxNewCapacity parameter

### DIFF
--- a/Data/Parameters/Par_GroupTotalAnnualMaxNewCap/Par_GroupTotalAnnualMaxNewCap.csv
+++ b/Data/Parameters/Par_GroupTotalAnnualMaxNewCap/Par_GroupTotalAnnualMaxNewCap.csv
@@ -1,0 +1,1 @@
+TechnologySubset,RegionSubset,Year,Value,,Unit,Source,Updated at,Updated by


### PR DESCRIPTION
# 📌 Pull Request Summary

Companion to the model's new TCC5 constraint: caps the summed annual NewCapacity of a technology subset x region subset per year. Same schema as Par_GroupTotalAnnualMaxCapacity (TechnologySubset, RegionSubset, Year, Value); no rows or a 999999 value means no limit. Picked up automatically by the conversion like the other group parameters.

See also https://github.com/GENeSYS-MOD/GENeSYSMOD.jl/pull/51

## 🔗 Related Issue(s)

Closes # (issue number, if applicable)

## 🛠️ Changes Introduced

- adds placeholder file for the new parameter, automatically gets picked up by the conversion script

## 📋 Checklist

- [ ] Code follows project conventions
- [ ] Tests have been added/updated (if needed)
- [ ] Documentation has been updated (if applicable)
- [ ] Relevant issues linked
- [ ] Reviewers assigned
